### PR TITLE
feat(BTMA-2599): Add 'Voting' API tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+API_KEY=secretKey

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.54.2",
-        "@types/node": "^24.2.0"
+        "@types/node": "^24.2.0",
+        "dotenv": "^17.2.1"
       }
     },
     "node_modules/@playwright/test": {
@@ -37,6 +38,19 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/fsevents": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,19 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.54.2",
-        "@types/node": "^24.2.0",
-        "dotenv": "^17.2.1"
+        "@playwright/test": "1.54.2",
+        "@types/node": "24.2.0",
+        "dotenv": "17.2.1"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
-      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.54.2"
+        "playwright": "1.55.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz",
-      "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -69,13 +69,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
-      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.54.2"
+        "playwright-core": "1.55.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -88,9 +88,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
-      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "description": "",
   "devDependencies": {
     "@playwright/test": "^1.54.2",
-    "@types/node": "^24.2.0"
+    "@types/node": "^24.2.0",
+    "dotenv": "^17.2.1"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
+import * as dotenv from "dotenv";
+dotenv.config();
 
 /**
  * Read environment variables from file.

--- a/src/api/abstract.ts
+++ b/src/api/abstract.ts
@@ -1,0 +1,5 @@
+import { APIRequestContext } from "@playwright/test";
+
+export abstract class BaseAPI {
+  constructor(protected request: APIRequestContext) {}
+}

--- a/src/api/controllers/types/voteController.type.ts
+++ b/src/api/controllers/types/voteController.type.ts
@@ -1,0 +1,17 @@
+export type CreateVoteRequest = {
+  image_id: string; // I set it to not required to be able to miss it in test which checks the required field
+  sub_id: string;
+  value: any;
+};
+
+export type PartialVoteRequest = Partial<CreateVoteRequest>;
+
+export type CreateVoteResponse = {
+  [x: string]: any;
+  message: string;
+  id: number;
+  image_id: string;
+  sub_id: string;
+  value: any;
+  country_code: string;
+};

--- a/src/api/controllers/types/voteController.type.ts
+++ b/src/api/controllers/types/voteController.type.ts
@@ -7,7 +7,6 @@ export type CreateVoteRequest = {
 export type PartialVoteRequest = Partial<CreateVoteRequest>;
 
 export type CreateVoteResponse = {
-  [x: string]: any;
   message: string;
   id: number;
   image_id: string;

--- a/src/api/controllers/types/voteController.type.ts
+++ b/src/api/controllers/types/voteController.type.ts
@@ -1,7 +1,7 @@
 export type CreateVoteRequest = {
-  image_id: string; // I set it to not required to be able to miss it in test which checks the required field
+  image_id: string;
   sub_id: string;
-  value: any;
+  value: number | string | boolean;
 };
 
 export type PartialVoteRequest = Partial<CreateVoteRequest>;
@@ -12,5 +12,5 @@ export type CreateVoteResponse = {
   image_id: string;
   sub_id: string;
   value: any;
-  country_code: string;
+  country_code: number;
 };

--- a/src/api/controllers/voteController.ts
+++ b/src/api/controllers/voteController.ts
@@ -1,0 +1,62 @@
+import { BaseAPI } from "../abstract";
+import {
+  CreateVoteResponse,
+  CreateVoteRequest,
+  PartialVoteRequest,
+} from "./types/voteController.type";
+
+export class VoteController extends BaseAPI {
+  private baseUrl = "https://api.thecatapi.com/v1";
+
+  private headers() {
+    if (!process.env.API_KEY) {
+      throw new Error("API_KEY is not defined");
+    }
+    return {
+      "x-api-key": process.env.API_KEY,
+      "Content-Type": "application/json",
+    };
+  }
+
+  async addVote(
+    data: CreateVoteRequest | PartialVoteRequest
+  ): Promise<CreateVoteResponse> {
+    const response = await this.request.post(`${this.baseUrl}/votes`, {
+      data,
+      headers: this.headers(),
+    });
+    if (!response.ok()) {
+      const errorMessage = await response.text();
+      throw new Error(`${errorMessage}`);
+    }
+    return (await response.json()) as CreateVoteResponse;
+  }
+
+  async getVote(sub_id?: string): Promise<CreateVoteResponse[]> {
+    const params = new URLSearchParams();
+    if (sub_id) params.append("sub_id", sub_id);
+
+    const response = await this.request.get(
+      `${this.baseUrl}/votes?sub_id=${sub_id}`,
+      {
+        headers: this.headers(),
+      }
+    );
+    if (!response.ok()) {
+      const errorMessage = await response.text();
+      throw new Error(`${errorMessage}`);
+    }
+    return (await response.json()) as CreateVoteResponse[];
+  }
+
+  async deleteVote(id: number): Promise<{ message: string }> {
+    const response = await this.request.delete(`${this.baseUrl}/votes/${id}`, {
+      headers: this.headers(),
+    });
+    if (!response.ok()) {
+      const errorMessage = await response.text();
+      throw new Error(`${errorMessage}`);
+    }
+    return (await response.json()) as { message: string };
+  }
+}

--- a/src/api/controllers/voteController.ts
+++ b/src/api/controllers/voteController.ts
@@ -18,9 +18,7 @@ export class VoteController extends BaseAPI {
     };
   }
 
-  async addVote(
-    data: CreateVoteRequest | PartialVoteRequest
-  ): Promise<CreateVoteResponse> {
+  async addVote(data: PartialVoteRequest): Promise<CreateVoteResponse> {
     const response = await this.request.post(`${this.baseUrl}/votes`, {
       data,
       headers: this.headers(),
@@ -29,7 +27,7 @@ export class VoteController extends BaseAPI {
       const errorMessage = await response.text();
       throw new Error(`${errorMessage}`);
     }
-    return (await response.json()) as CreateVoteResponse;
+    return await response.json();
   }
 
   async getVote(sub_id?: string): Promise<CreateVoteResponse[]> {
@@ -46,7 +44,7 @@ export class VoteController extends BaseAPI {
       const errorMessage = await response.text();
       throw new Error(`${errorMessage}`);
     }
-    return (await response.json()) as CreateVoteResponse[];
+    return await response.json();
   }
 
   async deleteVote(id: number): Promise<{ message: string }> {
@@ -57,6 +55,6 @@ export class VoteController extends BaseAPI {
       const errorMessage = await response.text();
       throw new Error(`${errorMessage}`);
     }
-    return (await response.json()) as { message: string };
+    return await response.json();
   }
 }

--- a/src/app/abstract.ts
+++ b/src/app/abstract.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 
 export abstract class PageHolder {
   constructor(protected page: Page) {}
@@ -6,6 +6,10 @@ export abstract class PageHolder {
 
 export abstract class Component extends PageHolder {
   abstract expectLoaded(): Promise<void>;
+
+  async expectToHaveTextOnElement(locator: Locator, text: string) {
+    await expect(locator).toHaveText(text);
+  }
 }
 
 export abstract class AppPage extends Component {

--- a/src/app/components/frame.ts
+++ b/src/app/components/frame.ts
@@ -1,4 +1,4 @@
-import { expect } from "@playwright/test";
+import { BrowserContext, expect } from "@playwright/test";
 import { Component } from "../abstract";
 
 export class FrameComponent extends Component {
@@ -13,6 +13,6 @@ export class FrameComponent extends Component {
   }
 
   async verifyBtnTextAfterClick() {
-    await expect(this.frameBtn).toHaveText("Clicked");
+    await this.expectToHaveTextOnElement(this.frameBtn, "Clicked");
   }
 }

--- a/src/app/components/popupWindow.ts
+++ b/src/app/components/popupWindow.ts
@@ -13,7 +13,7 @@ export class PopupComponent extends Component {
     await this.openPopupBtn.click();
   }
 
-  async clickAndGetNewPage() {
+  async openNewPage() {
     const pagePromise = this.page.waitForEvent("popup");
     await this.clickOpenPopupBtn();
     return new FrameComponent(await pagePromise);

--- a/src/app/components/popupWindow.ts
+++ b/src/app/components/popupWindow.ts
@@ -1,5 +1,6 @@
 import { expect } from "@playwright/test";
 import { Component } from "../abstract";
+import { FrameComponent } from "./frame";
 
 export class PopupComponent extends Component {
   private openPopupBtn = this.page.locator("#window1");
@@ -10,5 +11,11 @@ export class PopupComponent extends Component {
 
   async clickOpenPopupBtn() {
     await this.openPopupBtn.click();
+  }
+
+  async clickAndGetNewPage() {
+    const pagePromise = this.page.waitForEvent("popup");
+    await this.clickOpenPopupBtn();
+    return new FrameComponent(await pagePromise);
   }
 }

--- a/src/tests/handleWindows.test.ts
+++ b/src/tests/handleWindows.test.ts
@@ -4,14 +4,9 @@ import { FrameComponent } from "../app/components/frame";
 
 test("check opening multiple windows", async ({ page, context }) => {
   const waitConditions = new WaitConditionsPage(page);
-
   await waitConditions.openPopup();
   await waitConditions.verifyPopupOpened();
-
-  const pagePromise = context.waitForEvent("page");
-  await waitConditions.clickBtnOnPopup();
-
-  const frame = new FrameComponent(await pagePromise);
+  const frame = await waitConditions.popup.openNewPage();
   await frame.expectLoaded();
   await frame.clickButton();
   await frame.verifyBtnTextAfterClick();

--- a/src/tests/voteApi.test.ts
+++ b/src/tests/voteApi.test.ts
@@ -1,0 +1,106 @@
+import { test, expect } from "@playwright/test";
+import { VoteController } from "../api/controllers/voteController";
+import {
+  CreateVoteResponse,
+  PartialVoteRequest,
+} from "../api/controllers/types/voteController.type";
+import { expectToThrow } from "../utils/testUtils";
+
+test.describe("Vote API tests", () => {
+  let voteController: VoteController;
+  const body = {
+    image_id: "imageId",
+    sub_id: `my-user-${Date.now()}`,
+    value: 1,
+  };
+
+  test.beforeEach(async ({ request }) => {
+    voteController = new VoteController(request);
+  });
+
+  test("check vote up", async () => {
+    const response = await voteController.addVote(body);
+    expect(response).toMatchObject({ ...body, message: "SUCCESS" });
+  });
+
+  test("check vote down", async () => {
+    const response = await voteController.addVote({ ...body, value: -1 });
+    expect(response).toMatchObject({ ...body, value: -1, message: "SUCCESS" });
+  });
+
+  test("check that image_id is required in adding vote request", async () => {
+    const { image_id, ...bodyWithoutImage } = body;
+    await expectToThrow(
+      () => voteController.addVote(bodyWithoutImage as PartialVoteRequest),
+      '"image_id" is required'
+    );
+  });
+
+  test("check that value is required in adding vote request", async () => {
+    const { value, ...bodyWithoutValue } = body;
+    await expectToThrow(
+      () => voteController.addVote(bodyWithoutValue as PartialVoteRequest),
+      '"value" is required'
+    );
+  });
+
+  test("check that image_id can not be number", async () => {
+    const bodyWithWrongImageType: PartialVoteRequest = {
+      ...body,
+      image_id: 1 as any,
+    };
+    await expectToThrow(
+      () => voteController.addVote(bodyWithWrongImageType),
+      '"image_id" must be a string'
+    );
+  });
+
+  test("check that image_id can not be boolean", async () => {
+    const bodyWithWrongImageType: PartialVoteRequest = {
+      ...body,
+      image_id: true as any,
+    };
+    await expectToThrow(
+      () => voteController.addVote(bodyWithWrongImageType),
+      '"image_id" must be a string'
+    );
+  });
+
+  test("check that sub_id can not be number", async () => {
+    const bodyWithWrongSubIdType: PartialVoteRequest = {
+      ...body,
+      sub_id: 1 as any,
+    };
+    await expectToThrow(
+      () => voteController.addVote(bodyWithWrongSubIdType),
+      '"sub_id" must be a string'
+    );
+  });
+
+  test("check that sub_id can not be boolean", async () => {
+    const bodyWithWrongSubIdType: PartialVoteRequest = {
+      ...body,
+      sub_id: false as any,
+    };
+    await expectToThrow(
+      () => voteController.addVote(bodyWithWrongSubIdType),
+      '"sub_id" must be a string'
+    );
+  });
+
+  test("check creating and getting vote by sub_id", async () => {
+    await voteController.addVote(body);
+    const response = (await voteController.getVote(
+      `my-user-${Date.now()}`
+    )) as CreateVoteResponse[];
+    const filterResponse = response.map((obj) => obj.sub_id);
+    expect(filterResponse.every((obj) => obj === body.sub_id)).toBeTruthy();
+  });
+
+  test("check creating and deleting vote", async () => {
+    const createdVote = await voteController.addVote(body);
+    const voteId = createdVote.id;
+    const deleteResponse = await voteController.deleteVote(voteId);
+    expect(deleteResponse.message).toBe("SUCCESS");
+  });
+});

--- a/src/tests/voteApi.test.ts
+++ b/src/tests/voteApi.test.ts
@@ -1,9 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { VoteController } from "../api/controllers/voteController";
-import {
-  CreateVoteResponse,
-  PartialVoteRequest,
-} from "../api/controllers/types/voteController.type";
+import { PartialVoteRequest } from "../api/controllers/types/voteController.type";
 import { expectToThrow } from "../utils/testUtils";
 
 test.describe("Vote API tests", () => {

--- a/src/tests/voteApi.test.ts
+++ b/src/tests/voteApi.test.ts
@@ -31,7 +31,7 @@ test.describe("Vote API tests", () => {
   test("check that image_id is required in adding vote request", async () => {
     const { image_id, ...bodyWithoutImage } = body;
     await expectToThrow(
-      () => voteController.addVote(bodyWithoutImage as PartialVoteRequest),
+      () => voteController.addVote(bodyWithoutImage),
       '"image_id" is required'
     );
   });
@@ -39,7 +39,7 @@ test.describe("Vote API tests", () => {
   test("check that value is required in adding vote request", async () => {
     const { value, ...bodyWithoutValue } = body;
     await expectToThrow(
-      () => voteController.addVote(bodyWithoutValue as PartialVoteRequest),
+      () => voteController.addVote(bodyWithoutValue),
       '"value" is required'
     );
   });
@@ -90,11 +90,8 @@ test.describe("Vote API tests", () => {
 
   test("check creating and getting vote by sub_id", async () => {
     await voteController.addVote(body);
-    const response = (await voteController.getVote(
-      `my-user-${Date.now()}`
-    )) as CreateVoteResponse[];
-    const filterResponse = response.map((obj) => obj.sub_id);
-    expect(filterResponse.every((obj) => obj === body.sub_id)).toBeTruthy();
+    const response = await voteController.getVote(`my-user-${Date.now()}`);
+    expect(response.every((res) => res.sub_id === body.sub_id)).toBeTruthy();
   });
 
   test("check creating and deleting vote", async () => {

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -1,0 +1,14 @@
+import { expect } from "@playwright/test";
+
+export async function expectToThrow(
+  action: () => Promise<unknown>,
+  expectedMessage: string
+) {
+  try {
+    await action();
+    throw new Error("Error is expected");
+  } catch (err) {
+    const error = err as Error;
+    expect(error.message).toContain(expectedMessage);
+  }
+}

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -4,11 +4,5 @@ export async function expectToThrow(
   action: () => Promise<unknown>,
   expectedMessage: string
 ) {
-  try {
-    await action();
-    throw new Error("Error is expected");
-  } catch (err) {
-    const error = err as Error;
-    expect(error.message).toContain(expectedMessage);
-  }
+  await expect(action()).rejects.toThrow(expectedMessage);
 }


### PR DESCRIPTION
### Changes: 📝

1. Created separate `voteController.ts` controller where  methods to add/get/delete vote are difined
2. Created `voteController.type.ts` to define request/response types
3. Used Native PW 'Request' class 
4. Used 'Headers' as Authorization mechanism. 
5. Used error handling inside methods to process errors
6. Created tests where controller is instantiated to make actual requests
7. Asserted results with non-async 'expect' methods

Link to API: https://developers.thecatapi.com/

### Jira ticket’s link: 🔗
https://newsiteam.atlassian.net/browse/BTMA-2599

### Screenshot: 📷
<img width="459" height="339" alt="image" src="https://github.com/user-attachments/assets/2fb43067-8a5f-4828-b59d-03ddd3f29342" />

### Checklist for Reviewer: ✅

- [ ] Created controller for adding/deleting/getting votes.
- [ ] Created simple tests that trigger API endpoints and verify its response. 
- [ ] Code published to your repository (on your separate feat branch). A PR is created.
- [ ] The changes are reviewed and approved by at least on teammate.
- [ ] Changes are merged into the main branch after PR approval.